### PR TITLE
Only match ASCII digits in from_string() method.

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,9 @@ Changes for Perl extension DateTime-Tiny
 
 {{$NEXT}}
 
+1.07
+    - Bugfix: only match ASCII digits in from_string() method.
+
 1.06      2016-06-23 09:43:41-04:00 America/New_York
     - No changes from 1.05
 

--- a/lib/DateTime/Tiny.pm
+++ b/lib/DateTime/Tiny.pm
@@ -197,7 +197,8 @@ sub from_string {
 		require Carp;
 		Carp::croak("Did not provide a string to from_string");
 	}
-	unless ( $string =~ /^(\d\d\d\d)-(\d\d)-(\d\d)T(\d\d):(\d\d):(\d\d)$/ ) {
+    my $d = '[0-9]'; # backwards-compatible way of not matching anything but ASCII digits
+	unless ( $string =~ /^($d$d$d$d)-($d$d)-($d$d)T($d$d):($d$d):($d$d)$/ ) {
 		require Carp;
 		Carp::croak("Invalid time format (does not match ISO 8601)");
 	}

--- a/t/02_main.t
+++ b/t/02_main.t
@@ -8,8 +8,9 @@ BEGIN {
 	$^W = 1;	
 }
 
-use Test::More tests => 31;
+use Test::More tests => 32;
 use DateTime::Tiny;
+use utf8;
 
 
 
@@ -113,4 +114,11 @@ SCOPE: {
 		DateTime::Tiny->from_string( $tiny->as_string ),
 		$tiny, '->from_string ok',
 	);
+}
+
+SCOPE: {
+    eval { DateTime::Tiny->from_string('୭୮୯௦-௧௨-௩௪T௫௬:௭௮:௯౦') };
+    my $error = $@;
+    like $error, qr/\QInvalid time format (does not match ISO 8601)/,
+      'Only ASCII digits are valid in datetime strings';
 }


### PR DESCRIPTION
This code currently works:

``` perl
my $datetime = DateTime::Tiny->from_string('୭୮୯௦-௧௨-௩௪T௫௬:௭௮:௯౦');
```

But it spits out warnings when you try to print it via `as_string()` because `\d` in regexes matches more than just ASCII digits. The following test program shows the problem:

``` perl
use 5.10.0;
use utf8::all;
my $num_matched = 0;
for ( 1 .. 2**16 ) {
    my $char = chr($_);

    if ( $char =~ /\d/ ) {
        $num_matched++;
        say "$_ => $char";
    }
}
say "$num_matched characters matched";
#350 characters matched
```

The pull request substitutes `[0-9]` for `\d` in the `from_string()` regex (thus being compatible with older Perls) to fix this issue. There is a test to verify the expected exception.
