### PR TITLE
Fix locale test for newer DateTime::Locale (again)

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Changes for Perl extension DateTime-Tiny
 
 {{$NEXT}}
 
+    - Fix tests with DateTime::Locale 1.33 and later
+
 1.07      2018-04-22 11:06:08+02:00 Europe/Oslo
 
     - Bugfix: only match ASCII digits in from_string() method.

--- a/t/02_main.t
+++ b/t/02_main.t
@@ -78,8 +78,9 @@ SKIP: {
 	my $dt = $date->DateTime;
 	isa_ok( $dt, 'DateTime' );
 	# DateTime::Locale version 1.00 changes "C" to "en-US-POSIX".
-	my $expected = eval { DateTime::Locale->VERSION(1) } ? "en-US-POSIX" : "C";
-	is( $dt->locale->id,      $expected,  '->locale ok'   );
+	# And version 1.33 changes to "en-US".
+	my %expected = map { $_ => 1 } qw(C en-US-POSIX en-US);
+	ok( $expected{ $dt->locale->id }, '->locale ok' );
 	is( $dt->time_zone->name, 'floating', '->timezone ok' );
 
 	# Compare accessor results


### PR DESCRIPTION
Version 1.33 changes from "en-US-POSIX" to "en-US". This particular solution drops the version check and supports all three possible values.

I ran perltidy against t/02_main.t, but there were a tonne of whitespace changes. So I erred on the side on having a small diff.

Cheers!