### PR TITLE
Fix the check of the DateTime::Local id #3

### DIFF
--- a/t/02_main.t
+++ b/t/02_main.t
@@ -78,8 +78,8 @@ SKIP: {
 	my $dt = $date->DateTime;
 	isa_ok( $dt, 'DateTime' );
 	# DateTime::Locale version 1.00 changes "C" to "en-US-POSIX".
-	my $expected = eval { DateTime::Locale->VERSION(1) } ? "en-US-POSIX" : "C";
-	is( $dt->locale->id,      $expected,  '->locale ok'   );
+	my $expected = eval { DateTime::Locale->VERSION(1) } ? qr/^en-US(-POSIX)?$/ : qr/^C$/;
+	like( $dt->locale->id,      $expected,  '->locale ok'   );
 	is( $dt->time_zone->name, 'floating', '->timezone ok' );
 
 	# Compare accessor results


### PR DESCRIPTION
DateTime::Locale v1.33 changes "en-US-POSIX" to "en-US". See https://metacpan.org/dist/DateTime-Locale/changes

Fixes #3.